### PR TITLE
Ensamble de piezo, MIDI y lectura botón de sustain

### DIFF
--- a/miditambor_midi.ino
+++ b/miditambor_midi.ino
@@ -1,24 +1,67 @@
+#include "MIDIUSB.h"
 
+int piezo = A0;           // Pin de entrada de piezoeléctrico
+int threshold = 50;       // Umbral de piezoeléctrico
 
-int noteOn = 144;
-int piezo = A0;
-int threshold = 50;//anything over fifty means we've hit the piezo
+const int buttonPin = 2;  // Pin de entrada de botón
+int buttonState = 0;      // Estado del botón
 
+int note = 144;           // Nota a enviar
+int onTime = 200;         // Tiempo en milisegundos hasta enviar el noteOff
+uint8_t intensity = 64;   // Intensidad de nota
+signed char channel = 0;  // Canal de envío MIDI
+
+/*
+ *      SETUP
+ */
 void setup(){
-  Serial.begin(9600);
+  Serial.begin(115200);
+  pinMode(buttonPin, INPUT);
 }
 
+/*
+ *      LOOP
+ */
 void loop(){
+  sensePiezo();
+}
+
+// Sensamos piezo. Si supera umbral, enviamos la nota
+void sensePiezo(){
   int piezoVal = analogRead(piezo);
-  if (piezoVal>threshold){
-    MIDImessage(noteOn, 60, 127);
-    delay(300);
-    MIDImessage(noteOn, 60, 0);
+  if (piezoVal > threshold){
+    playNote();
   }
 }
 
-//send MIDI message
-void MIDImessage(byte command, byte data1, byte data2) {
-  Serial.write(command);
-  Serial.write(data1);
-  Serial.write(data2);
+// Envía el noteOn y checkea estado del botón
+void playNote(){
+  noteOn(channel, note, intensity);
+  MidiUSB.flush();
+  checkButton();
+}
+
+// Si el botón está en alto, se llama recursivamente, sino envía noteOff
+void checkButton(){
+  buttonState = digitalRead(buttonPin);
+  if (buttonState == HIGH) {
+    delay(onTime);
+    checkButton();
+  } else {
+    delay(onTime);
+    noteOff(channel, note, 0);
+    MidiUSB.flush();
+  }
+}
+
+// Envío de señal midi noteOn
+void noteOn(byte channel, byte pitch, byte velocity) {
+  midiEventPacket_t noteOn = {0x09, 0x90, pitch, velocity};
+  MidiUSB.sendMIDI(noteOn);
+}
+
+// Envío de señal midi noteOff
+void noteOff(byte channel, byte pitch, byte velocity) {
+  midiEventPacket_t noteOff = {0x08, 0x80, pitch, velocity};
+  MidiUSB.sendMIDI(noteOff);
+}


### PR DESCRIPTION
- Sensado de piezo
- Envío de note on en caso de superar el umbral al sensar el piezo
- Checkeo de botón en pin 2 para comprobar si tiene o no que enviar el note off (sustain)
- Funciones para envío de noteOn y noteOff

* No usar pines digitales 0 y 1 (Tx y Rx) mientras se quiera usar el protocolo de serie, son estos los puertos que utiliza arduino para comunicarse con la PC